### PR TITLE
Encode speed optimizations

### DIFF
--- a/fpnge.cc
+++ b/fpnge.cc
@@ -602,6 +602,8 @@ void TryPredictor(size_t bytes_per_line_buf, const unsigned char *mask,
     auto bytes = MMSI(load)((MIVEC *)predicted_data);
 
     auto data_for_lut = MMSI(and)(MM(set1_epi8)(0xF), bytes);
+    // get a mask of `bytes` that are between -16 and 15 inclusive
+    // (`-16 <= bytes <= 15` is equivalent to `bytes + 112 > 95`)
     auto use_lowhi = MM(cmpgt_epi8)(MM(add_epi8)(bytes, MM(set1_epi8)(112)),
                                     MM(set1_epi8)(95));
 
@@ -810,6 +812,8 @@ void EncodeOneRow(size_t bytes_per_line_buf,
     auto maskv = MMSI(load)((MIVEC *)mask);
 
     auto data_for_lut = MMSI(and)(MM(set1_epi8)(0xF), bytes);
+    // get a mask of `bytes` that are between -16 and 15 inclusive
+    // (`-16 <= bytes <= 15` is equivalent to `bytes + 112 > 95`)
     auto use_lowhi = MM(cmpgt_epi8)(MM(add_epi8)(bytes, MM(set1_epi8)(112)),
                                     MM(set1_epi8)(95));
     auto data_for_midlut =

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -275,7 +275,7 @@ struct BitWriter {
     bits_in_buffer += count;
     memcpy(data + bytes_written, &buffer, 8);
     size_t bytes_in_buffer = bits_in_buffer / 8;
-    bits_in_buffer -= bytes_in_buffer * 8;
+    bits_in_buffer &= 7;
     buffer >>= bytes_in_buffer * 8;
     bytes_written += bytes_in_buffer;
   }
@@ -751,7 +751,7 @@ FORCE_INLINE void WriteBits(MIVEC nbits, MIVEC bits_lo, MIVEC bits_hi,
     bits_in_buffer += count;
     memcpy(writer->data + bytes_written, &buffer, 8);
     size_t bytes_in_buffer = bits_in_buffer / 8;
-    bits_in_buffer -= bytes_in_buffer * 8;
+    bits_in_buffer &= 7;
     buffer >>= bytes_in_buffer * 8;
     bytes_written += bytes_in_buffer;
   }

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -511,8 +511,8 @@ ProcessRow(size_t bytes_per_line_buf, const unsigned char *mask,
       auto min_ac = MM(min_epu8)(a, c);
       auto pa = MM(sub_epi8)(MM(max_epu8)(b, c), min_bc);
       auto pb = MM(sub_epi8)(MM(max_epu8)(a, c), min_ac);
-      // pc = |b-c + a-c| = |pa-pb|, unless a>c>b or b>c>a, in which case, pc
-      // isn't used
+      // pc = |(b-c) + (a-c)| = |pa-pb|, unless a>c>b or b>c>a, in which case,
+      // pc isn't used
       auto min_pab = MM(min_epu8)(pa, pb);
       auto pc = MM(sub_epi8)(MM(max_epu8)(pa, pb), min_pab);
       pc = MMSI(or)(


### PR DESCRIPTION
First batch of optimizations. These shouldn't affect the output in any way.

Comparison on a Ryzen 3900X:

	Old code - image 1
	   191.916 MP/s
		10.787 bits/pixel
	Old code - image 2
	   241.242 MP/s
		16.240 bits/pixel
	
	New code - image 1
	   204.904 MP/s
		10.787 bits/pixel
	New code - image 2
	   260.227 MP/s
		16.240 bits/pixel

CLA response: I release these changes to the public domain subject to the CC0 license (https://creativecommons.org/publicdomain/zero/1.0/).