### PR TITLE
Remove mask/adler buffers

### DIFF
--- a/fpnge.cc
+++ b/fpnge.cc
@@ -478,10 +478,10 @@ static uint32_t hadd(MIVEC v) {
 }
 
 template <size_t predictor>
-FORCE_INLINE MIVEC PredictVec(const unsigned char *current_buf,
-                              const unsigned char *top_buf,
-                              const unsigned char *left_buf,
-                              const unsigned char *topleft_buf) {
+static FORCE_INLINE MIVEC PredictVec(const unsigned char *current_buf,
+                                     const unsigned char *top_buf,
+                                     const unsigned char *left_buf,
+                                     const unsigned char *topleft_buf) {
   auto data = MMSI(load)((MIVEC *)(current_buf));
   if (predictor == 0) {
     return data;
@@ -539,16 +539,16 @@ FORCE_INLINE MIVEC PredictVec(const unsigned char *current_buf,
   }
 }
 
-alignas(SIMD_WIDTH) const int32_t _kMaskVec[] = {-1, -1, -1, -1,
+alignas(SIMD_WIDTH) constexpr int32_t _kMaskVec[] = {-1, -1, -1, -1,
 #if SIMD_WIDTH == 32
-                                                 -1, -1, -1, -1, 0, 0, 0, 0,
+                                                     -1, -1, -1, -1, 0, 0, 0, 0,
 #endif
-                                                 0,  0,  0,  0};
+                                                     0,  0,  0,  0};
 const uint8_t *kMaskVec =
     reinterpret_cast<const uint8_t *>(_kMaskVec) + SIMD_WIDTH;
 
 template <size_t predictor, typename CB, typename CB_ADL, typename CB_RLE>
-static FORCE_INLINE void
+static void
 ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
            const unsigned char *top_buf, const unsigned char *left_buf,
            const unsigned char *topleft_buf, CB &&cb, CB_ADL &&cb_adl,

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -544,7 +544,8 @@ alignas(SIMD_WIDTH) const int32_t _kMaskVec[] = {-1, -1, -1, -1,
                                                  -1, -1, -1, -1, 0, 0, 0, 0,
 #endif
                                                  0,  0,  0,  0};
-const uint8_t *kMaskVec = (const uint8_t *)_kMaskVec + SIMD_WIDTH;
+const uint8_t *kMaskVec =
+    reinterpret_cast<const uint8_t *>(_kMaskVec) + SIMD_WIDTH;
 
 template <size_t predictor, typename CB, typename CB_ADL, typename CB_RLE>
 static FORCE_INLINE void

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -23,16 +23,10 @@
 #if defined(_MSC_VER) && !defined(__clang__)
 #define FORCE_INLINE_LAMBDA [[msvc::forceinline]]
 #define FORCE_INLINE __forceinline
-static FORCE_INLINE unsigned BSF32(unsigned v) {
-  unsigned long idx;
-  _BitScanForward(&idx, v);
-  return idx;
-}
 #define __SSE4_1__ 1
 #else
 #define FORCE_INLINE_LAMBDA __attribute__((always_inline))
 #define FORCE_INLINE __attribute__((always_inline)) inline
-#define BSF32 __builtin_ctzl
 #endif
 
 #include <wmmintrin.h> // for CLMUL
@@ -45,6 +39,7 @@ static FORCE_INLINE unsigned BSF32(unsigned v) {
 #define BCAST128 _mm256_broadcastsi128_si256
 #define INT2VEC(v) _mm256_castsi128_si256(_mm_cvtsi32_si128(v))
 #define SIMD_WIDTH 32
+#define SIMD_MASK 0xffffffffU
 #elif defined(__SSE4_1__)
 #include <nmmintrin.h>
 #define MM(f) _mm_##f
@@ -53,6 +48,7 @@ static FORCE_INLINE unsigned BSF32(unsigned v) {
 #define BCAST128(v) (v)
 #define INT2VEC _mm_cvtsi32_si128
 #define SIMD_WIDTH 16
+#define SIMD_MASK 0xffffU
 #else
 #error Requires SSE4.1 support minium
 #endif
@@ -543,40 +539,55 @@ FORCE_INLINE MIVEC PredictVec(const unsigned char *current_buf,
   }
 }
 
+alignas(SIMD_WIDTH) const int32_t _kMaskVec[] = {-1, -1, -1, -1,
+#if SIMD_WIDTH == 32
+                                                 -1, -1, -1, -1, 0, 0, 0, 0,
+#endif
+                                                 0,  0,  0,  0};
+const uint8_t *kMaskVec = (const uint8_t *)_kMaskVec + SIMD_WIDTH;
+
 template <size_t predictor, typename CB, typename CB_ADL, typename CB_RLE>
 static FORCE_INLINE void
-ProcessRow(size_t bytes_per_line_buf, const unsigned char *mask,
-           const unsigned char *current_row_buf, const unsigned char *top_buf,
-           const unsigned char *left_buf, const unsigned char *topleft_buf,
-           CB &&cb, CB_ADL &&cb_adl, CB_RLE &&cb_rle) {
+ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
+           const unsigned char *top_buf, const unsigned char *left_buf,
+           const unsigned char *topleft_buf, CB &&cb, CB_ADL &&cb_adl,
+           CB_RLE &&cb_rle) {
   size_t run = 0;
-  for (size_t i = 0; i + SIMD_WIDTH <= bytes_per_line_buf; i += SIMD_WIDTH) {
+  size_t i = 0;
+  for (; i + SIMD_WIDTH <= bytes_per_line; i += SIMD_WIDTH) {
     auto pdata = PredictVec<predictor>(current_row_buf + i, top_buf + i,
                                        left_buf + i, topleft_buf + i);
-    auto maskv = MMSI(load)((MIVEC *)(mask + i));
-
-    size_t bytes_per_vec = _mm_popcnt_u32(MM(movemask_epi8)(maskv));
-
-    auto pdatais0 = MM(cmpeq_epi8)(pdata, MMSI(setzero)());
-    auto isnot0 = MMSI(andnot)(pdatais0, maskv);
-
-    unsigned next0run =
-#ifdef __AVX2__
-        _tzcnt_u32(MM(movemask_epi8)(isnot0));
-#else
-        BSF32((1UL << SIMD_WIDTH) | MM(movemask_epi8)(isnot0));
-#endif
-
-    if (next0run == bytes_per_vec && run + bytes_per_vec >= 16) {
-      run += bytes_per_vec;
+    unsigned pdatais0 =
+        MM(movemask_epi8)(MM(cmpeq_epi8)(pdata, MMSI(setzero)()));
+    if (pdatais0 == SIMD_MASK) {
+      run += SIMD_WIDTH;
     } else {
       if (run != 0) {
         cb_rle(run);
       }
       run = 0;
-      cb(pdata, mask + i);
+      cb(pdata, SIMD_WIDTH);
     }
-    cb_adl(bytes_per_vec, pdata, mask + i, i);
+    cb_adl(SIMD_WIDTH, pdata, SIMD_WIDTH, i);
+  }
+  size_t bytes_remaining = bytes_per_line ^ i;
+  if (bytes_remaining) {
+    auto pdata = PredictVec<predictor>(current_row_buf + i, top_buf + i,
+                                       left_buf + i, topleft_buf + i);
+    unsigned pdatais0 =
+        MM(movemask_epi8)(MM(cmpeq_epi8)(pdata, MMSI(setzero)()));
+    auto mask = (1UL << bytes_remaining) - 1;
+
+    if ((pdatais0 & mask) == mask && run + bytes_remaining >= 16) {
+      run += bytes_remaining;
+    } else {
+      if (run != 0) {
+        cb_rle(run);
+      }
+      run = 0;
+      cb(pdata, bytes_remaining);
+    }
+    cb_adl(bytes_remaining, pdata, bytes_remaining, i);
   }
   if (run != 0) {
     cb_rle(run);
@@ -602,15 +613,14 @@ template <typename CB> static void ForAllRLESymbols(size_t length, CB &&cb) {
 
 template <size_t pred>
 static void
-TryPredictor(size_t bytes_per_line_buf, const unsigned char *mask,
-             const unsigned char *current_row_buf, const unsigned char *top_buf,
-             const unsigned char *left_buf, const unsigned char *topleft_buf,
-             const HuffmanTable &table, size_t &best_cost, uint8_t &predictor,
-             size_t dist_nbits) {
+TryPredictor(size_t bytes_per_line, const unsigned char *current_row_buf,
+             const unsigned char *top_buf, const unsigned char *left_buf,
+             const unsigned char *topleft_buf, const HuffmanTable &table,
+             size_t &best_cost, uint8_t &predictor, size_t dist_nbits) {
   size_t cost_rle = 0;
   MIVEC cost_direct = MMSI(setzero)();
   auto cost_chunk_cb = [&](const MIVEC bytes,
-                           const uint8_t *mask) FORCE_INLINE_LAMBDA {
+                           const size_t bytes_in_vec) FORCE_INLINE_LAMBDA {
     auto data_for_lut = MMSI(and)(MM(set1_epi8)(0xF), bytes);
     // get a mask of `bytes` that are between -16 and 15 inclusive
     // (`-16 <= bytes <= 15` is equivalent to `bytes + 112 > 95`)
@@ -625,14 +635,15 @@ TryPredictor(size_t bytes_per_line_buf, const unsigned char *mask,
     auto nbits = MM(blendv_epi8)(nbits_low16, nbits_hi16, bytes);
     nbits = MM(blendv_epi8)(MM(set1_epi8)(table.mid_nbits), nbits, use_lowhi);
 
-    nbits = MMSI(and)(nbits, MMSI(load)((MIVEC *)mask));
+    nbits = MMSI(and)(nbits, MMSI(loadu)((MIVEC *)(kMaskVec - bytes_in_vec)));
 
     cost_direct =
         MM(add_epi32)(cost_direct, MM(sad_epu8)(nbits, MMSI(setzero)()));
   };
   ProcessRow<pred>(
-      bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf, topleft_buf,
-      cost_chunk_cb, [](size_t, const MIVEC, const uint8_t *, size_t) {},
+      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf,
+      cost_chunk_cb,
+      [](size_t, const MIVEC, const size_t bytes_in_vec, size_t) {},
       [&](size_t run) {
         cost_rle += table.first16_nbits[0];
         ForAllRLESymbols(run, [&](size_t len) {
@@ -762,23 +773,22 @@ static FORCE_INLINE void WriteBits(MIVEC nbits, MIVEC bits_lo, MIVEC bits_hi,
 }
 
 static void
-EncodeOneRow(size_t bytes_per_line_buf,
-             const uint8_t *aligned_adler_mul_buf_ptr,
-             const unsigned char *mask, const unsigned char *current_row_buf,
-             const unsigned char *top_buf, const unsigned char *left_buf,
-             const unsigned char *topleft_buf, const HuffmanTable &table,
-             uint32_t &s1, uint32_t &s2, size_t dist_nbits, size_t dist_bits,
+EncodeOneRow(size_t bytes_per_line, const uint8_t *aligned_adler_mul_buf_ptr,
+             const unsigned char *current_row_buf, const unsigned char *top_buf,
+             const unsigned char *left_buf, const unsigned char *topleft_buf,
+             const HuffmanTable &table, uint32_t &s1, uint32_t &s2,
+             size_t dist_nbits, size_t dist_bits,
              BitWriter *__restrict writer) {
 #ifndef FPNGE_FIXED_PREDICTOR
   uint8_t predictor;
   size_t best_cost = ~0U;
-  TryPredictor<1>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+  TryPredictor<1>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, table, best_cost, predictor, dist_nbits);
-  TryPredictor<2>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+  TryPredictor<2>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, table, best_cost, predictor, dist_nbits);
-  TryPredictor<3>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+  TryPredictor<3>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, table, best_cost, predictor, dist_nbits);
-  TryPredictor<4>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+  TryPredictor<4>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, table, best_cost, predictor, dist_nbits);
 #else
   uint8_t predictor = FPNGE_FIXED_PREDICTOR;
@@ -805,8 +815,8 @@ EncodeOneRow(size_t bytes_per_line_buf,
     last_adler_flush = len;
   };
 
-  auto encode_chunk_cb = [&](const MIVEC bytes, const uint8_t *mask) {
-    auto maskv = MMSI(load)((MIVEC *)mask);
+  auto encode_chunk_cb = [&](const MIVEC bytes, const size_t bytes_in_vec) {
+    auto maskv = MMSI(loadu)((MIVEC *)(kMaskVec - bytes_in_vec));
 
     auto data_for_lut = MMSI(and)(MM(set1_epi8)(0xF), bytes);
     // get a mask of `bytes` that are between -16 and 15 inclusive
@@ -849,14 +859,15 @@ EncodeOneRow(size_t bytes_per_line_buf,
   };
 
   auto adler_chunk_cb = [&](size_t bytes_per_vec, const MIVEC pdata,
-                            const uint8_t *mask, size_t i) {
+                            const size_t bytes_in_vec, size_t i) {
     len += bytes_per_vec;
 
     adler_accum_s2 = MM(add_epi32)(
         MM(mullo_epi32)(MM(set1_epi32)(bytes_per_vec), adler_accum_s1),
         adler_accum_s2);
 
-    auto bytes = MMSI(and)(pdata, MMSI(load)((MIVEC *)mask));
+    auto bytes =
+        MMSI(and)(pdata, MMSI(loadu)((MIVEC *)(kMaskVec - bytes_in_vec)));
 
     adler_accum_s1 =
         MM(add_epi32)(adler_accum_s1, MM(sad_epu8)(bytes, MMSI(setzero)()));
@@ -881,43 +892,45 @@ EncodeOneRow(size_t bytes_per_line_buf,
 
 #ifdef FPNGE_FIXED_PREDICTOR
   if (predictor == 0) {
-    ProcessRow<0>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+    ProcessRow<0>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
   } else
 #endif
       if (predictor == 1) {
-    ProcessRow<1>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+    ProcessRow<1>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
   } else if (predictor == 2) {
-    ProcessRow<2>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+    ProcessRow<2>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
   } else if (predictor == 3) {
-    ProcessRow<3>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+    ProcessRow<3>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
   } else {
     assert(predictor == 4);
-    ProcessRow<4>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
+    ProcessRow<4>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
   }
 
   flush_adler();
 }
 
-static void CollectSymbolCounts(
-    size_t bytes_per_line_buf, const uint8_t *aligned_adler_mul_buf_ptr,
-    const unsigned char *mask, const unsigned char *current_row_buf,
-    const unsigned char *top_buf, const unsigned char *left_buf,
-    const unsigned char *topleft_buf, uint64_t *__restrict symbol_counts) {
+static void CollectSymbolCounts(size_t bytes_per_line,
+                                const uint8_t *aligned_adler_mul_buf_ptr,
+                                const unsigned char *current_row_buf,
+                                const unsigned char *top_buf,
+                                const unsigned char *left_buf,
+                                const unsigned char *topleft_buf,
+                                uint64_t *__restrict symbol_counts) {
 
-  auto encode_chunk_cb = [&](const MIVEC pdata, const uint8_t *mask) {
+  auto encode_chunk_cb = [&](const MIVEC pdata, const size_t bytes_in_vec) {
     alignas(SIMD_WIDTH) uint8_t predicted_data[SIMD_WIDTH];
     MMSI(store)((MIVEC *)predicted_data, pdata);
-    for (size_t i = 0; i < SIMD_WIDTH; i++) {
-      symbol_counts[predicted_data[i]] += mask[i] != 0;
+    for (size_t i = 0; i < bytes_in_vec; i++) {
+      symbol_counts[predicted_data[i]] += 1;
     }
   };
 
-  auto adler_chunk_cb = [&](size_t, const MIVEC, const uint8_t *, size_t) {};
+  auto adler_chunk_cb = [&](size_t, const MIVEC, const size_t, size_t) {};
 
   auto encode_rle_cb = [&](size_t run) {
     symbol_counts[0] += 1;
@@ -947,12 +960,12 @@ static void CollectSymbolCounts(
   };
 
 #ifdef FPNGE_FIXED_PREDICTOR
-  ProcessRow<FPNGE_FIXED_PREDICTOR>(
-      bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf, topleft_buf,
-      encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
+  ProcessRow<FPNGE_FIXED_PREDICTOR>(bytes_per_line, current_row_buf, top_buf,
+                                    left_buf, topleft_buf, encode_chunk_cb,
+                                    adler_chunk_cb, encode_rle_cb);
 #else
-  ProcessRow<4>(bytes_per_line_buf, mask, current_row_buf, top_buf, left_buf,
-                topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
+  ProcessRow<4>(bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf,
+                encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
 #endif
 }
 
@@ -1012,13 +1025,6 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
                          ? (SIMD_WIDTH - (intptr_t)aligned_buf_ptr % SIMD_WIDTH)
                          : 0;
 
-  std::vector<unsigned char> mask_buf(bytes_per_line_buf + SIMD_WIDTH - 1);
-  unsigned char *aligned_mask_buf_ptr = mask_buf.data();
-  aligned_mask_buf_ptr +=
-      (intptr_t)aligned_mask_buf_ptr % SIMD_WIDTH
-          ? (SIMD_WIDTH - (intptr_t)aligned_mask_buf_ptr % SIMD_WIDTH)
-          : 0;
-
   std::vector<unsigned char> adler_mul_buf(bytes_per_line_buf + SIMD_WIDTH - 1);
   unsigned char *aligned_adler_mul_buf_ptr = adler_mul_buf.data();
   aligned_adler_mul_buf_ptr +=
@@ -1026,8 +1032,7 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
           ? (SIMD_WIDTH - (intptr_t)aligned_adler_mul_buf_ptr % SIMD_WIDTH)
           : 0;
 
-  // Initialize the mask & adler multipliers data.
-  memset(aligned_mask_buf_ptr, 0xFF, bytes_per_line);
+  // Initialize the adler multipliers data.
   memset(aligned_adler_mul_buf_ptr, 0x01, bytes_per_line);
   for (size_t i = 0; i < bytes_per_line; i += SIMD_WIDTH) {
     for (size_t ii = SIMD_WIDTH - 1; ii-- > 0;) {
@@ -1073,9 +1078,9 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
       continue;
     }
 
-    CollectSymbolCounts(bytes_per_line_buf, aligned_adler_mul_buf_ptr,
-                        aligned_mask_buf_ptr, current_row_buf, top_buf,
-                        left_buf, topleft_buf, symbol_counts);
+    CollectSymbolCounts(bytes_per_line, aligned_adler_mul_buf_ptr,
+                        current_row_buf, top_buf, left_buf, topleft_buf,
+                        symbol_counts);
   }
 
   memset(buf.data(), 0, buf.size());
@@ -1105,10 +1110,9 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
 
     memcpy(current_row_buf, current_row_in, bytes_per_line);
 
-    EncodeOneRow(bytes_per_line_buf, aligned_adler_mul_buf_ptr,
-                 aligned_mask_buf_ptr, current_row_buf, top_buf, left_buf,
-                 topleft_buf, huffman_table, s1, s2, dist_nbits, dist_bits,
-                 &writer);
+    EncodeOneRow(bytes_per_line, aligned_adler_mul_buf_ptr, current_row_buf,
+                 top_buf, left_buf, topleft_buf, huffman_table, s1, s2,
+                 dist_nbits, dist_bits, &writer);
 
     size_t bytes = (writer.bytes_written - crc_pos) / 64 * 64;
     crc = update_crc(crc, writer.data + crc_pos, bytes);

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -877,6 +877,7 @@ EncodeOneRow(size_t bytes_per_line, const unsigned char *current_row_buf,
         17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
 #endif
     );
+    muls = MM(add_epi8)(muls, MM(set1_epi8)(bytes_in_vec - SIMD_WIDTH));
     auto bytesmuls = MM(maddubs_epi16)(bytes, muls);
     adler_accum_s2 = MM(add_epi32)(
         adler_accum_s2, MM(madd_epi16)(bytesmuls, MM(set1_epi16)(1)));

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -571,7 +571,7 @@ ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
     }
     cb_adl(pdata, SIMD_WIDTH);
   }
-  size_t bytes_remaining = bytes_per_line ^ i;
+  size_t bytes_remaining = bytes_per_line ^ i; // equivalent to `bytes_per_line - i`
   if (bytes_remaining) {
     auto pdata = PredictVec<predictor>(current_row_buf + i, top_buf + i,
                                        left_buf + i, topleft_buf + i);


### PR DESCRIPTION
Not sure if these buffers originally had different intended purposes, but removing them reduces cache usage, and simplifies a bunch of code.

This change also removes the POPCNT requirement, and may slightly change output as RLE now works on the last vector of the line.

This also seems to yield a minor performance benefit - on a 12700K:

~~~
Old code - image 1
   295.585 MP/s
    10.787 bits/pixel
Old code - image 2
   384.460 MP/s
    16.240 bits/pixel

New code - image 1
   308.533 MP/s
    10.787 bits/pixel
New code - image 2
   385.016 MP/s
    16.240 bits/pixel
~~~

CLA response: I release these changes to the public domain subject to the CC0 license (https://creativecommons.org/publicdomain/zero/1.0/).