### PR TITLE
Encode speed optimizations (2)

### DIFF
--- a/fpnge.cc
+++ b/fpnge.cc
@@ -694,9 +694,6 @@ static FORCE_INLINE void WriteBits(MIVEC nbits, MIVEC bits_lo, MIVEC bits_hi,
   _mm_storel_epi64((__m128i *)nbits_a, bit_count);
 #endif
 
-  alignas(SIMD_WIDTH) uint64_t bits_a[SIMD_WIDTH / 4];
-  MMSI(store)((MIVEC *)bits_a, bits0);
-  MMSI(store)((MIVEC *)bits_a + 1, bits1);
   alignas(SIMD_WIDTH) uint64_t bitmask_a[SIMD_WIDTH / 4];
   MMSI(store)((MIVEC *)bitmask_a, bitmask0);
   MMSI(store)((MIVEC *)bitmask_a + 1, bitmask1);
@@ -789,11 +786,12 @@ static FORCE_INLINE void WriteBits(MIVEC nbits, MIVEC bits_lo, MIVEC bits_hi,
   // writer is safe.
   alignas(SIMD_WIDTH) uint32_t nbits_a[SIMD_WIDTH / 4];
   MMSI(store)((MIVEC *)nbits_a, nbits01);
+
+#endif
+
   alignas(SIMD_WIDTH) uint64_t bits_a[SIMD_WIDTH / 4];
   MMSI(store)((MIVEC *)bits_a, bits0);
   MMSI(store)((MIVEC *)bits_a + 1, bits1);
-
-#endif
 
 #ifdef __AVX2__
   constexpr uint8_t kPerm[] = {0, 1, 4, 5, 2, 3, 6, 7};

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -490,13 +490,8 @@ static uint32_t hadd(MIVEC v) {
 #else
       v;
 #endif
-  auto hi = _mm_unpackhi_epi64(sum, sum);
-
-  sum = _mm_add_epi32(hi, sum);
-  hi = _mm_shuffle_epi32(sum, 0xB1);
-
-  sum = _mm_add_epi32(sum, hi);
-
+  sum = _mm_hadd_epi32(sum, sum);
+  sum = _mm_hadd_epi32(sum, sum);
   return _mm_cvtsi128_si32(sum);
 }
 

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -904,9 +904,10 @@ EncodeOneRow(size_t bytes_per_line_buf,
     bits_lo = MM(blendv_epi8)(bits_mid_lo, bits_lo, use_lowhi);
 
     bits_lo = MMSI(and)(bits_lo, maskv);
-
-    auto bits_hi = MMSI(and)(
-        bits_mid_hi, MM(cmpeq_epi8)(nbits, MM(set1_epi8)(table.mid_nbits)));
+    auto bits_hi = MMSI(andnot)(use_lowhi, bits_mid_hi);
+    // maskv doesn't need to explicitly be applied to bits_hi: this is because
+    // bytes past the end of the line are zeroed out, meaning that use_lowhi
+    // would be set for those, and masked out above
 
     WriteBits(nbits, bits_lo, bits_hi, table.mid_nbits - 4, writer);
   };


### PR DESCRIPTION
Second batch of optimizations. These shouldn't affect the output in any way.

Most of this is an implementation of *WriteBits* using the `PEXT` instruction, which is disabled on CPUs with a slow implementation of it (AMD CPUs before Zen3).

Comparison on a 12700K:

~~~
Old code - image 1
   295.585 MP/s
    10.787 bits/pixel
Old code - image 2
   384.460 MP/s
    16.240 bits/pixel

New code - image 1
   302.302 MP/s
    10.787 bits/pixel
New code - image 2
   397.900 MP/s
    16.240 bits/pixel
~~~

CLA response: I release these changes to the public domain subject to the CC0 license (https://creativecommons.org/publicdomain/zero/1.0/).