### PR TITLE
Encode speed optimizations (3)

### DIFF
--- a/fpnge.cc
+++ b/fpnge.cc
@@ -557,7 +557,7 @@ alignas(SIMD_WIDTH) const int32_t _kMaskVec[] = {0,  0,  0,  0,
 #if SIMD_WIDTH == 32
                                                  0,  0,  0,  0, -1, -1, -1, -1,
 #endif
-                                                 -1, -1, -1, -1};
+                                                     -1, -1, -1, -1};
 const uint8_t *kMaskVec =
     reinterpret_cast<const uint8_t *>(_kMaskVec) + SIMD_WIDTH;
 
@@ -732,8 +732,8 @@ static FORCE_INLINE void WriteBitsLong(MIVEC nbits, MIVEC bits_lo,
   }
 
   // 16 -> 32
-  auto nbits0_32_lo = MMSI(and)(nbits0, MM(set1_epi32)(0xFF));
-  auto nbits1_32_lo = MMSI(and)(nbits1, MM(set1_epi32)(0xFF));
+  auto nbits0_32_lo = MMSI(and)(nbits0, MM(set1_epi32)(0xFFFF));
+  auto nbits1_32_lo = MMSI(and)(nbits1, MM(set1_epi32)(0xFFFF));
 
   auto bits0_32_lo = MMSI(and)(bits0, MM(set1_epi32)(0xFFFF));
   auto bits1_32_lo = MMSI(and)(bits1, MM(set1_epi32)(0xFFFF));
@@ -772,8 +772,8 @@ static FORCE_INLINE void WriteBitsLong(MIVEC nbits, MIVEC bits_lo,
   bits0 = MM(srlv_epi64)(bits0, nbits_inv0_64_lo);
   bits1 = MM(srlv_epi64)(bits1, nbits_inv1_64_lo);
 #else
-  auto nbits0_64_lo = MMSI(and)(nbits0, MM(set1_epi64x)(0xFF));
-  auto nbits1_64_lo = MMSI(and)(nbits1, MM(set1_epi64x)(0xFF));
+  auto nbits0_64_lo = MMSI(and)(nbits0, MM(set1_epi64x)(0xFFFFFFFF));
+  auto nbits1_64_lo = MMSI(and)(nbits1, MM(set1_epi64x)(0xFFFFFFFF));
   // just do two shifts for SSE variant
   auto bits0_64_lo = MMSI(and)(bits0_32, MM(set1_epi64x)(0xFFFFFFFF));
   auto bits1_64_lo = MMSI(and)(bits1_32, MM(set1_epi64x)(0xFFFFFFFF));

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -553,9 +553,10 @@ static FORCE_INLINE MIVEC PredictVec(const unsigned char *current_buf,
   }
 }
 
-alignas(SIMD_WIDTH) const int32_t _kMaskVec[] = {0,  0,  0,  0,
+alignas(SIMD_WIDTH) constexpr int32_t _kMaskVec[] = {0,  0,  0,  0,
 #if SIMD_WIDTH == 32
-                                                 0,  0,  0,  0, -1, -1, -1, -1,
+                                                     0,  0,  0,  0,
+                                                     -1, -1, -1, -1,
 #endif
                                                      -1, -1, -1, -1};
 const uint8_t *kMaskVec =
@@ -585,7 +586,8 @@ ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
     }
     cb_adl(pdata, SIMD_WIDTH);
   }
-  size_t bytes_remaining = bytes_per_line ^ i; // equivalent to `bytes_per_line - i`
+  size_t bytes_remaining =
+      bytes_per_line ^ i; // equivalent to `bytes_per_line - i`
   if (bytes_remaining) {
     auto pdata = PredictVec<predictor>(current_row_buf + i, top_buf + i,
                                        left_buf + i, topleft_buf + i);


### PR DESCRIPTION
Last batch of optimizations. These shouldn't affect the output in any way.

The largest change comes from the observation that most symbols will be <= 8 bits, since we expect compression to work, so a shortcut can be taken in this common case.

Comparison on a 12700K:

~~~
Old code - image 1
   311.271 MP/s
    10.787 bits/pixel
Old code - image 2
   394.295 MP/s
    16.240 bits/pixel

New code - image 1
   392.560 MP/s
    10.787 bits/pixel
New code - image 2
   423.004 MP/s
    16.240 bits/pixel
~~~

CLA response: I release these changes to the public domain subject to the CC0 license (https://creativecommons.org/publicdomain/zero/1.0/).