### PR TITLE
Re-use Paeth predicted data from TryPredictor

### DIFF
--- a/fpnge.cc
+++ b/fpnge.cc
@@ -562,21 +562,17 @@ alignas(SIMD_WIDTH) constexpr int32_t _kMaskVec[] = {0,  0,  0,  0,
 const uint8_t *kMaskVec =
     reinterpret_cast<const uint8_t *>(_kMaskVec) + SIMD_WIDTH;
 
-template <size_t predictor, bool store_pred = false, typename CB,
-          typename CB_ADL, typename CB_RLE>
+template <size_t predictor, typename CB, typename CB_ADL, typename CB_RLE>
 static void
 ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
            const unsigned char *top_buf, const unsigned char *left_buf,
            const unsigned char *topleft_buf, CB &&cb, CB_ADL &&cb_adl,
-           CB_RLE &&cb_rle, unsigned char *predicted_data = nullptr) {
+           CB_RLE &&cb_rle) {
   size_t run = 0;
   size_t i = 0;
   for (; i + SIMD_WIDTH <= bytes_per_line; i += SIMD_WIDTH) {
     auto pdata = PredictVec<predictor>(current_row_buf + i, top_buf + i,
                                        left_buf + i, topleft_buf + i);
-    if (store_pred) {
-      MMSI(store)((MIVEC *)(predicted_data + i), pdata);
-    }
     unsigned pdatais0 =
         MM(movemask_epi8)(MM(cmpeq_epi8)(pdata, MMSI(setzero)()));
     if (pdatais0 == SIMD_MASK) {
@@ -588,16 +584,13 @@ ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
       run = 0;
       cb(pdata, SIMD_WIDTH);
     }
-    cb_adl(pdata, SIMD_WIDTH);
+    cb_adl(pdata, SIMD_WIDTH, i);
   }
   size_t bytes_remaining =
       bytes_per_line ^ i; // equivalent to `bytes_per_line - i`
   if (bytes_remaining) {
     auto pdata = PredictVec<predictor>(current_row_buf + i, top_buf + i,
                                        left_buf + i, topleft_buf + i);
-    if (store_pred) {
-      MMSI(store)((MIVEC *)(predicted_data + i), pdata);
-    }
     unsigned pdatais0 =
         MM(movemask_epi8)(MM(cmpeq_epi8)(pdata, MMSI(setzero)()));
     auto mask = (1UL << bytes_remaining) - 1;
@@ -611,7 +604,7 @@ ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
       run = 0;
       cb(pdata, bytes_remaining);
     }
-    cb_adl(pdata, bytes_remaining);
+    cb_adl(pdata, bytes_remaining, i);
   }
   if (run != 0) {
     cb_rle(run);
@@ -673,16 +666,25 @@ TryPredictor(size_t bytes_per_line, const unsigned char *current_row_buf,
     cost_direct =
         MM(add_epi32)(cost_direct, MM(sad_epu8)(nbits, nbits_discard));
   };
-  ProcessRow<pred, store_pred>(
-      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf,
-      cost_chunk_cb, [](const MIVEC, size_t) {},
-      [&](size_t run) {
-        cost_rle += table.first16_nbits[0];
-        ForAllRLESymbols(run, [&](size_t len, size_t count) {
-          cost_rle += (dist_nbits + table.lz77_length_nbits[len]) * count;
-        });
-      },
-      predicted_data);
+  auto rle_cost_cb = [&](size_t run) {
+    cost_rle += table.first16_nbits[0];
+    ForAllRLESymbols(run, [&](size_t len, size_t count) {
+      cost_rle += (dist_nbits + table.lz77_length_nbits[len]) * count;
+    });
+  };
+  if (store_pred) {
+    ProcessRow<pred>(
+        bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf,
+        cost_chunk_cb,
+        [=](const MIVEC pdata, size_t, size_t i) {
+          MMSI(store)((MIVEC *)(predicted_data + i), pdata);
+        },
+        rle_cost_cb);
+  } else {
+    ProcessRow<pred>(
+        bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf,
+        cost_chunk_cb, [](const MIVEC, size_t, size_t) {}, rle_cost_cb);
+  }
   size_t cost = cost_rle + hadd(cost_direct);
   if (cost < best_cost) {
     best_cost = cost;
@@ -942,18 +944,18 @@ EncodeOneRow(size_t bytes_per_line, const unsigned char *current_row_buf,
 #ifndef FPNGE_FIXED_PREDICTOR
   uint8_t predictor;
   size_t best_cost = ~0U;
-  TryPredictor<1, false>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                         topleft_buf, nullptr, table, best_cost, predictor,
-                         dist_nbits);
-  TryPredictor<2, false>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                         topleft_buf, nullptr, table, best_cost, predictor,
-                         dist_nbits);
-  TryPredictor<3, false>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                         topleft_buf, nullptr, table, best_cost, predictor,
-                         dist_nbits);
-  TryPredictor<4, true>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                        topleft_buf, predicted_data, table, best_cost,
-                        predictor, dist_nbits);
+  TryPredictor<1, /*store_pred=*/false>(
+      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf, nullptr,
+      table, best_cost, predictor, dist_nbits);
+  TryPredictor<2, /*store_pred=*/false>(
+      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf, nullptr,
+      table, best_cost, predictor, dist_nbits);
+  TryPredictor<3, /*store_pred=*/false>(
+      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf, nullptr,
+      table, best_cost, predictor, dist_nbits);
+  TryPredictor<4, /*store_pred=*/true>(bytes_per_line, current_row_buf, top_buf,
+                                       left_buf, topleft_buf, predicted_data,
+                                       table, best_cost, predictor, dist_nbits);
 #else
   uint8_t predictor = FPNGE_FIXED_PREDICTOR;
 #endif
@@ -1033,7 +1035,7 @@ EncodeOneRow(size_t bytes_per_line, const unsigned char *current_row_buf,
     }
   };
 
-  auto adler_chunk_cb = [&](const MIVEC pdata, size_t bytes_in_vec) {
+  auto adler_chunk_cb = [&](const MIVEC pdata, size_t bytes_in_vec, size_t) {
     bytes_since_flush += bytes_in_vec;
     auto bytes = pdata;
 
@@ -1125,7 +1127,7 @@ static void CollectSymbolCounts(size_t bytes_per_line,
     }
   };
 
-  auto adler_chunk_cb = [&](const MIVEC, size_t) {};
+  auto adler_chunk_cb = [&](const MIVEC, size_t, size_t) {};
 
   auto encode_rle_cb = [&](size_t run) {
     symbol_counts[0] += 1;


### PR DESCRIPTION
Most of PNG's predictors are fairly trivial to compute, however Paeth is relatively slow. It also happens to be the most often chosen predictor. This results in Paeth being computed twice for many rows.

The idea of this change is to save the Paeth predicted data during `TryPredictor`, then re-use this during actual encoding.  
It's likely not worth doing this for the other predictors, due to being fast to compute and being less likely chosen.

Comparison on a 12700K:

~~~
Old code - image 1
   378.738 MP/s
    10.787 bits/pixel
Old code - image 2
   414.767 MP/s
    16.240 bits/pixel

New code - image 1
   447.864 MP/s
    10.787 bits/pixel
New code - image 2
   457.003 MP/s
    16.240 bits/pixel
~~~

CLA response: I release these changes to the public domain subject to the CC0 license (https://creativecommons.org/publicdomain/zero/1.0/).