### PR TITLE
Add fast approximation for predictor search

### DIFF
--- a/fpnge.cc
+++ b/fpnge.cc
@@ -322,9 +322,9 @@ struct HuffmanTable {
   // estimate for CollectSymbolCounts
   // only fills nbits; skips computing actual codes
   HuffmanTable() {
-    // the following is equivalent to ComputeNBits(0, 0, 0 ...), but much faster
+    // the following is similar to ComputeNBits(0, 0, 0 ...), but much faster
     constexpr uint8_t collapsed_nbits[] = {
-        2,  3,  4,  5,  5,  6,  6,  6,  7,  7,  8,  7,  8,  8,  8,  8,
+        2,  3,  4,  5,  5,  6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  8,
         8,  8,  8,  8,  8,  7,  7,  7,  7,  6,  6,  6,  5,  5,  4,  3,
 
         13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
@@ -1378,7 +1378,9 @@ CollectSymbolCounts(size_t bytes_per_line, const unsigned char *current_row_buf,
   ProcessRow<FPNGE_FIXED_PREDICTOR>(bytes_per_line, current_row_buf, top_buf,
                                     left_buf, topleft_buf, encode_chunk_cb,
                                     adler_chunk_cb, encode_rle_cb);
-#elif defined(FPNGE_SYM_TRIAL_PREDICT)
+#elif defined(FPNGE_APPROX_PREDICTOR)
+  // filter selection here seems to be slightly more effective when using the
+  // approximate selector; more investigation is probably warranted
   HuffmanTable dummy_table;
   uint8_t predictor =
       SelectPredictor(bytes_per_line, current_row_buf, top_buf, left_buf,

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,14 @@ run_default() {
   ./build/fpnge "$@"
 }
 
+prepare_approxpred() {
+  ./build.sh -DFPNGE_APPROX_PREDICTOR=1
+}
+
+run_approxpred() {
+  ./build/fpnge "$@"
+}
+
 prepare_fast() {
   ./build.sh -DFPNGE_FIXED_PREDICTOR=4
 }
@@ -54,7 +62,7 @@ run_testcase() {
 }
 
 
-for SETTING in default fast superfast
+for SETTING in default approxpred fast superfast
 do
   prepare_$SETTING
   for FILE in testdata/terminal.png $(find jxl_testdata -name '*.png')


### PR DESCRIPTION
From [prior discussions](https://github.com/veluca93/fpnge/pull/18#issuecomment-1196100565): adds `FPNGE_APPROX_PREDICTOR` switch to enable a fast approximation for predictor search. Benchmarks and effect on compression copied from previous thread:


~~~
--- speedup% --- size%
aggregate	+35.79	+0.12
photographic	+36.62	+0.02
synthetic	+35.97	+0.22
~~~

![](https://user-images.githubusercontent.com/12937885/181184112-500b892f-5c96-430b-b3b9-84c191d58999.png)
![](https://user-images.githubusercontent.com/12937885/181260400-d39aafbf-dfd6-40f4-8123-e44623eacfc7.png)

This doesn't really eliminate the other possible heuristics for predictor search that were discussed, as it doesn't attempt to skip it.

CLA response: I release these changes to the public domain subject to the CC0 license (https://creativecommons.org/publicdomain/zero/1.0/).