### PR TITLE
Add speed/compression runtime option

### DIFF
--- a/fpnge.cc
+++ b/fpnge.cc
@@ -1465,6 +1465,7 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
 
   // options sanity check
   assert(options->predictor >= 0 && options->predictor <= 6);
+  assert(options->huffman_sample >= 0 && options->huffman_sample <= 127);
 
   BitWriter writer;
   writer.data = static_cast<unsigned char *>(output);
@@ -1482,9 +1483,9 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
 
   uint64_t symbol_counts[286] = {};
 
-  // Sample ~1.5% of the rows in the center of the image.
-  size_t y0 = height * 126 / 256;
-  size_t y1 = height * 130 / 256;
+  // Sample rows in the center of the image.
+  size_t y0 = height * (127 - options->huffman_sample) / 256;
+  size_t y1 = height * (129 + options->huffman_sample) / 256;
   if (y1 == 0) { // for 1 pixel high images
     y1 = 1;
   }

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -735,10 +735,7 @@ ProcessRow(uint8_t predictor, size_t bytes_per_line,
            const unsigned char *current_row_buf, const unsigned char *top_buf,
            const unsigned char *left_buf, const unsigned char *topleft_buf,
            CB &&cb, CB_ADL &&cb_adl, CB_RLE &&cb_rle) {
-  if (predictor == 0) {
-    ProcessRow<0>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                  topleft_buf, cb, cb_adl, cb_rle);
-  } else if (predictor == 1) {
+  if (predictor == 1) {
     ProcessRow<1>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, cb, cb_adl, cb_rle);
   } else if (predictor == 2) {
@@ -747,9 +744,12 @@ ProcessRow(uint8_t predictor, size_t bytes_per_line,
   } else if (predictor == 3) {
     ProcessRow<3>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, cb, cb_adl, cb_rle);
-  } else {
-    assert(predictor == 4);
+  } else if(predictor == 4) {
     ProcessRow<4>(bytes_per_line, current_row_buf, top_buf, left_buf,
+                  topleft_buf, cb, cb_adl, cb_rle);
+  } else {
+    assert(predictor == 0);
+    ProcessRow<0>(bytes_per_line, current_row_buf, top_buf, left_buf,
                   topleft_buf, cb, cb_adl, cb_rle);
   }
 }

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -1486,7 +1486,7 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
   // Sample rows in the center of the image.
   size_t y0 = height * (127 - options->huffman_sample) / 256;
   size_t y1 = height * (129 + options->huffman_sample) / 256;
-  if (y1 == 0) { // for 1 pixel high images
+  if (y1 == 0 && height > 0) { // for 1 pixel high images
     y1 = 1;
   }
 

--- a/fpnge.cc
+++ b/fpnge.cc
@@ -1485,6 +1485,9 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
   // Sample ~1.5% of the rows in the center of the image.
   size_t y0 = height * 126 / 256;
   size_t y1 = height * 130 / 256;
+  if (y1 == 0) { // for 1 pixel high images
+    y1 = 1;
+  }
 
   for (size_t y = y0; y < y1; y++) {
     const unsigned char *current_row_in =
@@ -1499,7 +1502,7 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
         top_buf - bytes_per_channel * num_channels;
 
     memcpy(current_row_buf, current_row_in, bytes_per_line);
-    if (y == y0) {
+    if (y == y0 && y != 0) {
       continue;
     }
 

--- a/fpnge.h
+++ b/fpnge.h
@@ -19,9 +19,17 @@
 extern "C" {
 #endif
 
+enum FPNGEOptionsPredictor {
+  FPNGE_PREDICTOR_FIXED_NOOP,
+  FPNGE_PREDICTOR_FIXED_SUB,
+  FPNGE_PREDICTOR_FIXED_TOP,
+  FPNGE_PREDICTOR_FIXED_AVG,
+  FPNGE_PREDICTOR_FIXED_PAETH,
+  FPNGE_PREDICTOR_APPROX,
+  FPNGE_PREDICTOR_BEST
+};
 struct FPNGEOptions {
-  char predictor; // 0-4: fixed predictor, 5: fast predictor selection, 6: slow
-                  // predictor selection
+  char predictor;      // FPNGEOptionsPredictor
   char huffman_sample; // 0-127: how much of the image to sample
 };
 

--- a/fpnge.h
+++ b/fpnge.h
@@ -19,11 +19,38 @@
 extern "C" {
 #endif
 
+struct FPNGEOptions {
+  char predictor; // 0-4: fixed predictor, 5: fast predictor selection, 6: slow
+                  // predictor selection
+};
+
+#define FPNGE_COMPRESS_LEVEL_DEFAULT 4
+#define FPNGE_COMPRESS_LEVEL_BEST 4
+inline void FPNGEFillOptions(struct FPNGEOptions *options, int level) {
+  if (level == 0)
+    level = FPNGE_COMPRESS_LEVEL_DEFAULT;
+  switch (level) {
+  case 1:
+    options->predictor = 2;
+    break;
+  case 2:
+    options->predictor = 4;
+    break;
+  case 3:
+    options->predictor = 5;
+    break;
+  default:
+    options->predictor = 6;
+    break;
+  }
+}
+
 // bytes_per_channel = 1/2 for 8-bit and 16-bit. num_channels: 1/2/3/4
 // (G/GA/RGB/RGBA)
 size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
                    const void *data, size_t width, size_t row_stride,
-                   size_t height, void *output);
+                   size_t height, void *output,
+                   const struct FPNGEOptions *options);
 
 inline size_t FPNGEOutputAllocSize(size_t bytes_per_channel,
                                    size_t num_channels, size_t width,

--- a/fpnge.h
+++ b/fpnge.h
@@ -22,13 +22,15 @@ extern "C" {
 struct FPNGEOptions {
   char predictor; // 0-4: fixed predictor, 5: fast predictor selection, 6: slow
                   // predictor selection
+  char huffman_sample; // 0-127: how much of the image to sample
 };
 
 #define FPNGE_COMPRESS_LEVEL_DEFAULT 4
-#define FPNGE_COMPRESS_LEVEL_BEST 4
+#define FPNGE_COMPRESS_LEVEL_BEST 5
 inline void FPNGEFillOptions(struct FPNGEOptions *options, int level) {
   if (level == 0)
     level = FPNGE_COMPRESS_LEVEL_DEFAULT;
+  options->huffman_sample = 1;
   switch (level) {
   case 1:
     options->predictor = 2;
@@ -39,6 +41,9 @@ inline void FPNGEFillOptions(struct FPNGEOptions *options, int level) {
   case 3:
     options->predictor = 5;
     break;
+  case 5:
+    options->huffman_sample = 23;
+    // fall through
   default:
     options->predictor = 6;
     break;

--- a/test.sh
+++ b/test.sh
@@ -21,28 +21,16 @@ run_default() {
   ./build/fpnge "$@"
 }
 
-prepare_approxpred() {
-  ./build.sh -DFPNGE_APPROX_PREDICTOR=1
-}
-
 run_approxpred() {
-  ./build/fpnge "$@"
-}
-
-prepare_fast() {
-  ./build.sh -DFPNGE_FIXED_PREDICTOR=4
+  ./build/fpnge -3 "$@"
 }
 
 run_fast() {
-  ./build/fpnge "$@"
-}
-
-prepare_superfast() {
-  ./build.sh -DFPNGE_FIXED_PREDICTOR=2
+  ./build/fpnge -2 "$@"
 }
 
 run_superfast() {
-  ./build/fpnge "$@"
+  ./build/fpnge -1 "$@"
 }
 
 FAILURES=0
@@ -62,12 +50,15 @@ run_testcase() {
 }
 
 
-for SETTING in default approxpred fast superfast
+for BUILD in default
 do
-  prepare_$SETTING
-  for FILE in testdata/terminal.png $(find jxl_testdata -name '*.png')
+  prepare_$BUILD
+  for SETTING in default approxpred fast superfast
   do
-    run_testcase $SETTING $FILE
+    for FILE in testdata/terminal.png $(find jxl_testdata -name '*.png')
+    do
+      run_testcase $SETTING $FILE
+    done
   done
 done
 


### PR DESCRIPTION
As [discussed](https://github.com/veluca93/fpnge/pull/18#issuecomment-1198921875), this removes the defines for speed control, moving it into a runtime option.

This is done via a new parameter, which accepts an options struct. The struct can be filled with a function, given a compression level, allowing for both a (relatively) simple 'level' setting, and being able to configure behaviour more precisely. `NULL` can be passed as the new parameter to indicate that defaults should be used.  
The console application now accepts a `-1`..`-5` flag for the compression level.

CLA response: I release these changes to the public domain subject to the CC0 license (https://creativecommons.org/publicdomain/zero/1.0/).